### PR TITLE
JoinLogging file path is now portable

### DIFF
--- a/DeathmicChatbot/JoinLogger.cs
+++ b/DeathmicChatbot/JoinLogger.cs
@@ -129,7 +129,7 @@ namespace DeathmicChatbot
                 File.Create(sLogFilePath).Close();
         }
 
-        private static string GetLogFilePath(string sNick) { return string.Format(@"{0}\{1}.txt", LOGGING_DIRECTORY_NAME, sNick); }
+		private static string GetLogFilePath(string sNick) { return System.IO.Path.Combine(LOGGING_DIRECTORY_NAME, sNick + ".txt"); }
 
         private static void MakeSureLoggingDirectoryExists() { Directory.CreateDirectory(LOGGING_DIRECTORY_NAME); }
     }


### PR DESCRIPTION
It originally produced files name "join_logging\xyz.txt" when run on Linux.
Corrected to produce a file in a subdirectory on all platforms.
