### PR TITLE
Alias Merge and auto Reconnect on strange disconnect

### DIFF
--- a/DeathmicChatbot/Handlers/WebsiteHandler.cs
+++ b/DeathmicChatbot/Handlers/WebsiteHandler.cs
@@ -71,9 +71,27 @@ namespace DeathmicChatbot.Handlers
         private string GetPageTitleFromMetaTags(string url,
                                                 IList<HtmlNode> metaTags)
         {
-            var title =
-                HttpUtility.HtmlDecode(metaTags[0].InnerText)
-                           .Replace("\r\n", "");
+            var title = "";
+            foreach(var metatag in metaTags)
+            {
+                if (metatag.OuterHtml.Contains("title"))
+                {
+                    title = metatag.Attributes["title"].Value.Replace("\r\n", "");
+                }
+                else
+                {
+                    if (metatag.OuterHtml.Contains("description"))
+                    {
+                        title = metatag.Attributes["description"].Value.Replace("\r\n", "");
+                    }
+                    else
+                    {
+                        title =
+                    HttpUtility.HtmlDecode(metaTags[0].InnerText)
+                               .Replace("\r\n", "");
+                    }
+                }
+            }
             _log.WriteToLog("Information", url + " title: " + title);
             return title;
         }

--- a/DeathmicChatbot/Program.cs
+++ b/DeathmicChatbot/Program.cs
@@ -88,7 +88,11 @@ namespace DeathmicChatbot
         {
             if(_con != null)
             {
-                _con.Disconnect("Reconnect");
+                if(_con.Connected == false)
+                {
+                    _con.Disconnect("Reconnect");
+                }
+                
             }
             _cona = new ConnectionArgs(Nick, Server);
             _con = new Connection(Encoding.UTF8, _cona, false, false);

--- a/DeathmicChatbot/Program.cs
+++ b/DeathmicChatbot/Program.cs
@@ -79,7 +79,6 @@ namespace DeathmicChatbot
             }
             else
             {
-                reconnectinbound = false;
                 _con.Disconnect("Reconnect");
             }
             
@@ -142,17 +141,24 @@ namespace DeathmicChatbot
                                       string text,
                                       string commandArgs)
         {
-            string message = xmlprovider.AddStream(commandArgs,user.Nick);
-            _streamProviderManager.AddStream(commandArgs);
-            if(message == (user.Nick + " added Stream to the streamlist"))
+            try
             {
-                _messageQueue.PublicMessageEnqueue(channel,String.Format("{0} added {1} to the streamlist",user.Nick,commandArgs));
-            }
-            else if (message == (user.Nick + " wanted to readd Stream to the streamlist."))
+                string message = xmlprovider.AddStream(commandArgs, user.Nick);
+                _streamProviderManager.AddStream(commandArgs);
+                if (message == (user.Nick + " added Stream to the streamlist"))
+                {
+                    _messageQueue.PublicMessageEnqueue(channel, String.Format("{0} added {1} to the streamlist", user.Nick, commandArgs));
+                }
+                else if (message == (user.Nick + " wanted to readd Stream to the streamlist."))
+                {
+                    _con.Sender.Action(channel, String.Format("slaps {0} around for being an idiot", user.Nick));
+                }
+                _log.WriteToLog("Information", message);
+            }catch(Exception)
             {
-                _con.Sender.Action(channel,String.Format("slaps {0} around for being an idiot",user.Nick));
+                _log.WriteToLog("Information", "Fatal Error on AddStream");
             }
-            _log.WriteToLog("Information", message);
+            
         }
 
         private static void DelStream(UserInfo user,

--- a/DeathmicChatbot/Program.cs
+++ b/DeathmicChatbot/Program.cs
@@ -111,6 +111,7 @@ namespace DeathmicChatbot
                 _con.Connect();
             } while (!_con.Connected);
             reconnectinbound = false;
+            connectinginprogress = false;
             _messageQueue = new MessageQueue(_con);
         }
 

--- a/DeathmicChatbot/Program.cs
+++ b/DeathmicChatbot/Program.cs
@@ -135,11 +135,14 @@ namespace DeathmicChatbot
 
         private static void OnDisconnect()
         {
+
+            //commented out because it does not work on the strange case and other solution has been implemented which this would create a Exception
+            /*
             while (!IsConnectionPossible(_cona))
                 Console.WriteLine("OFFLINE");
             if (!_restarted)
-                Connect();
-            _restarted = true;
+                //Connect();
+            _restarted = true;*/
         }
 
         private static void AddStream(UserInfo user,

--- a/DeathmicChatbot/Program.cs
+++ b/DeathmicChatbot/Program.cs
@@ -88,7 +88,7 @@ namespace DeathmicChatbot
         {
             if(_con != null)
             {
-                if(_con.Connected == false)
+                if(_con.Connected == true)
                 {
                     _con.Disconnect("Reconnect");
                 }

--- a/DeathmicChatbot/Program.cs
+++ b/DeathmicChatbot/Program.cs
@@ -79,21 +79,14 @@ namespace DeathmicChatbot
             }
             else
             {
-                Connect();
+                reconnectinbound = false;
+                _con.Disconnect("Reconnect");
             }
             
         }
 
         private static void Connect()
         {
-            if(_con != null)
-            {
-                if(_con.Connected == true)
-                {
-                    _con.Disconnect("Reconnect");
-                }
-                
-            }
             _cona = new ConnectionArgs(Nick, Server);
             _con = new Connection(Encoding.UTF8, _cona, false, false);
             
@@ -136,13 +129,12 @@ namespace DeathmicChatbot
         private static void OnDisconnect()
         {
 
-            //commented out because it does not work on the strange case and other solution has been implemented which this would create a Exception
-            /*
+
             while (!IsConnectionPossible(_cona))
                 Console.WriteLine("OFFLINE");
             if (!_restarted)
-                //Connect();
-            _restarted = true;*/
+                Connect();
+            _restarted = true;
         }
 
         private static void AddStream(UserInfo user,

--- a/DeathmicChatbot/Program.cs
+++ b/DeathmicChatbot/Program.cs
@@ -44,6 +44,7 @@ namespace DeathmicChatbot
         private static readonly ICounter Counter = new Counter();
         private static IModel _model;
         private static bool reconnectinbound;
+        private static bool connectinginprogress = false;
 
         private static readonly ConcurrentDictionary<string, string> ChosenUsers
             = new ConcurrentDictionary<string, string>();
@@ -79,7 +80,12 @@ namespace DeathmicChatbot
             }
             else
             {
-                _con.Disconnect("Reconnect");
+                if(!connectinginprogress)
+                {
+                    connectinginprogress = true
+                    _con.Disconnect("Reconnect");
+                }
+                
             }
             
         }

--- a/DeathmicChatbot/Program.cs
+++ b/DeathmicChatbot/Program.cs
@@ -86,6 +86,7 @@ namespace DeathmicChatbot
 
         private static void Connect()
         {
+            _con.Disconnect("Reconnect");
             _cona = new ConnectionArgs(Nick, Server);
             _con = new Connection(Encoding.UTF8, _cona, false, false);
             
@@ -795,6 +796,7 @@ namespace DeathmicChatbot
 
         private static void Reconnect(UserInfo user, string text, string commandArgs)
         {
+            _con.Sender.Action("#Deathmic", "nick BotDeathmic");
             reconnectinbound = false;
         }
 

--- a/DeathmicChatbot/Program.cs
+++ b/DeathmicChatbot/Program.cs
@@ -79,7 +79,7 @@ namespace DeathmicChatbot
             }
             else
             {
-                Connect()
+                Connect();
             }
             
         }

--- a/DeathmicChatbot/Program.cs
+++ b/DeathmicChatbot/Program.cs
@@ -86,7 +86,10 @@ namespace DeathmicChatbot
 
         private static void Connect()
         {
-            _con.Disconnect("Reconnect");
+            if(_con != null)
+            {
+                _con.Disconnect("Reconnect");
+            }
             _cona = new ConnectionArgs(Nick, Server);
             _con = new Connection(Encoding.UTF8, _cona, false, false);
             

--- a/DeathmicChatbot/Program.cs
+++ b/DeathmicChatbot/Program.cs
@@ -82,7 +82,7 @@ namespace DeathmicChatbot
             {
                 if(!connectinginprogress)
                 {
-                    connectinginprogress = true
+                    connectinginprogress = true;
                     _con.Disconnect("Reconnect");
                 }
                 

--- a/DeathmicChatbot/Program.cs
+++ b/DeathmicChatbot/Program.cs
@@ -110,7 +110,7 @@ namespace DeathmicChatbot
             {
                 _con.Connect();
             } while (!_con.Connected);
-
+            reconnectinbound = false;
             _messageQueue = new MessageQueue(_con);
         }
 
@@ -136,7 +136,7 @@ namespace DeathmicChatbot
 
 
             while (!IsConnectionPossible(_cona))
-                Console.WriteLine("OFFLINE");
+                Console.WriteLine("Offline atempting reconnect");
             if (!_restarted)
                 Connect();
             _restarted = true;

--- a/DeathmicChatbot/XMLProvider.cs
+++ b/DeathmicChatbot/XMLProvider.cs
@@ -209,6 +209,7 @@ namespace DeathmicChatbot
                                     if (item2.Attribute("hasbeenmerged") == null)
                                     {
                                         int count = Int32.Parse(item.Attribute("VisitCount").Value);
+                                        item.Add(new XAttribute("oldcounter", item.Attribute("VisitCount").Value));
                                         item.Attribute("VisitCount").Value = (Int32.Parse(item2.Attribute("VisitCount").Value) + Int32.Parse(item.Attribute("VisitCount").Value)).ToString();
                                         item2.Add(new XAttribute("oldcounter", item2.Attribute("VisitCount").Value));
                                         item2.Attribute("VisitCount").Value = (Int32.Parse(item2.Attribute("VisitCount").Value) + count).ToString();

--- a/DeathmicChatbot/XMLProvider.cs
+++ b/DeathmicChatbot/XMLProvider.cs
@@ -19,14 +19,16 @@ namespace DeathmicChatbot
             {
                 XDocument xdoc = XDocument.Load("XML/Users.xml");
                 IEnumerable<XElement> childlist = from users in xdoc.Root.Elements() 
-                                                  where (users.Attribute("Nick").Value == nick
-                                                  || users.Element("Alias").Attribute("Value").Value == nick) && users.Attribute("Nick").Value != "BotDeathmic"
+                                                  where (users.Element("Alias").Attribute("Value").Value == nick
+                                                  || users.Attribute("Nick").Value == nick) && users.Attribute("Nick").Value != "BotDeathmic"
                                                   select users;
                 if(childlist.Count() > 0)
                 {
                     foreach (var user in childlist)
                     {
-                        answer += user.Attribute("VisitCount").Value + ",";
+                        int count = Int32.Parse(user.Attribute("VisitCount").Value);
+                        count++;
+                        answer += count.ToString() + ",";
                         answer += user.Attribute("LastVisit").Value;
                     }
                 }
@@ -199,12 +201,31 @@ namespace DeathmicChatbot
                         {
                             item.Add(new XElement("Alias", new XAttribute("Value", alias)));
                             xdoc.Save("XML/Users.xml");
+                            IEnumerable<XElement> childlist2 = from el in xdoc.Root.Elements() where el.Attribute("Nick").Value == alias select el;
+                            if (childlist2.Count() > 0)
+                            {
+                                foreach (XElement item2 in childlist2)
+                                {
+                                    if (item2.Attribute("hasbeenmerged") == null)
+                                    {
+                                        int count = Int32.Parse(item.Attribute("VisitCount").Value);
+                                        item.Attribute("VisitCount").Value = (Int32.Parse(item2.Attribute("VisitCount").Value) + Int32.Parse(item.Attribute("VisitCount").Value)).ToString();
+                                        item2.Add(new XAttribute("oldcounter", item2.Attribute("VisitCount").Value));
+                                        item2.Attribute("VisitCount").Value = (Int32.Parse(item2.Attribute("VisitCount").Value) + count).ToString();
+                                        item2.Add(new XAttribute("hasbeenmerged", 1));
+                                        xdoc.Save("XML/Users.xml");
+                                    }
+
+                                }
+
+                            }
                             return "Alias was added to the User";
                         }
                         else
                         {
                             return "Alias already added";
                         }
+                        
                         
                     }
                 }
@@ -416,12 +437,10 @@ namespace DeathmicChatbot
                 IEnumerable<XElement> childlist = from streams in xdoc.Root.Elements() where streams.Attribute("Channel").Value == channel select streams;
                 if (childlist.Count() > 0)
                 {
-
                     foreach (var stream in childlist)
                     {
                         answer = stream.Attribute(inforequested).Value;
                     }
-                    xdoc.Save("XML/Streams.xml");
                 }                
             }
             else


### PR DESCRIPTION
Alias Merge (no data lost)
- adds Alias to Nick + Adds Visit Count of each other to each other as well as writing visitcount before merge into extra attribute to enable potential remove Alias;
  auto Reconnect
  sends a command Message to itself (sets boolean to true aka reconnect in bound) sends message which if received turns boolean to false.
  if it stays true on the next timer event it triggers the Connection to Disconnect and thus reconnect as soon as it is possible again. In case of old instance still "online" atempts to change Nick every minute.
